### PR TITLE
fix: remove " character on first commit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ if (!options.skipGitInit) {
   try {
     await $`git init`;
     await $`git add .`;
-    await $`git commit -m "${'feat: initial commit'}"`;
+    await $`git commit -m ${'feat: initial commit'}`;
     spinner.succeed();
   } catch (error) {
     debug('Failed to initialize git repository', error);

--- a/src/lib/conf.ts
+++ b/src/lib/conf.ts
@@ -1,7 +1,7 @@
 import Conf from 'conf';
 
 type CliConfig = {
-  allowTelemetry?: boolean;
+  allowTelemetry?: boolean | undefined;
 };
 
 export const config = new Conf<CliConfig>({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
 
     "strict": true,
     "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
 
     "moduleResolution": "NodeNext",
     "module": "NodeNext",


### PR DESCRIPTION
When you init a start-ui project the first commit message is `"feat: initial commit"`

This PR fix it by removing trailing `"`

It also make the tsconfig stricter.